### PR TITLE
ISSUE-9

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ requirements in the examples listed.
 - `alias phpunit='./vendor/bin/phpunit'`
 - `alias gulp='node ./node_modules/gulp/bin/gulp'`
 
-#### Unit Tests
+### Unit Tests
 ##### Confirm PHPUnit installation works
 - `$ ./vendor/bin/phpcbf -h`
 - `$ ./vendor/bin/phpcbf -h`

--- a/src/LostSoul.php
+++ b/src/LostSoul.php
@@ -2,6 +2,7 @@
   /**
    *
    */
+  declare(strict_types=1);
 
   namespace DeeZone\Hug;
 

--- a/tests/LostSoulTest.php
+++ b/tests/LostSoulTest.php
@@ -23,9 +23,17 @@ final class LostSoulTest extends TestCase
   public function testReciprocatesHugs()
   {
     $lostSoul = new LostSoul();
+
+    // PHPUnit 4.5 and Prophecy
+    // https://thephp.cc/news/2015/02/phpunit-4-5-and-prophecy
     $mock = $this->prophesize(Huggable::class);
+
+    // Confirm the two LostSoul objects exchange hugs
     $mock->hug($lostSoul)->shouldBeCalled();
+
+    // reveal the prophecy and create an actual test double object
     $lostSoul->hug($mock->reveal());
+
   }
 
 }

--- a/tests/LostSoulTest.php
+++ b/tests/LostSoulTest.php
@@ -17,4 +17,15 @@ use PHPUnit\Framework\TestCase;
 final class LostSoulTest extends TestCase
 {
 
+  /**
+   *
+   */
+  public function testReciprocatesHugs()
+  {
+    $lostSoul = new LostSoul();
+    $mock = $this->prophesize(Huggable::class);
+    $mock->hug($lostSoul)->shouldBeCalled();
+    $lostSoul->hug($mock->reveal());
+  }
+
 }


### PR DESCRIPTION
Fixes #8 

- Adds basic test coverage of `LostSoul->hug()` to ensure hugs are exchanged between two `LostSoul` instances.  

```
$ ./vendor/bin/phpunit --verbose --testdox tests
PHPUnit 6.0.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.2 with Xdebug 2.5.1
Configuration: /Users/darrenlee/Documents/Projects/PSR-8/phpunit.xml.dist

DeeZone\Hug\LostSoul
 [x] Reciprocates hugs



Code Coverage Report:
  2017-03-22 04:36:02

 Summary:
  Classes: 100.00% (1/1)
  Methods: 100.00% (2/2)
  Lines:   100.00% (6/6)

\DeeZone\Hug::LostSoul
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% (  6/  6)
```