### PR TITLE
ISSUE-13 : 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ php index.php
 
 or listing of all coding volations by file.
 
+- `$ php ./vendor/bin/phpcs --standard=PSR2 --colors -s index.php src tests`
 - `$ php ./vendor/bin/phpcs --standard=./phpunit.xml.dest --colors -s index.php src tests`
 
 or automate processing of files that will be adjusted to meet coding standards.

--- a/src/LostSoul.php
+++ b/src/LostSoul.php
@@ -43,8 +43,8 @@ class LostSoul implements Huggable
         // An Exception is thrown as self hugging suggests an error in implimentation. Not a show stopper but should
         // be addressed.
         if ($soul === $this) {
-          throw new \Exception('WARNING: You should always love yourself but self hugging is not supported in the PSR-8' .
-              ' specification. An attept at an object hugging itself has been made.');
+            throw new \Exception('WARNING: You should always love yourself but self hugging is not supported in the ' .
+                'PSR-8 specification. An attept at an object hugging itself has been made.');
         }
 
         while ($this->loveFelt < $this->loveNeeded) {

--- a/tests/LostSoulTest.php
+++ b/tests/LostSoulTest.php
@@ -31,37 +31,37 @@ final class LostSoulTest extends TestCase
         $lostSoul->hug($mock->reveal());
     }
 
-  /**
-   * @expectedException \Exception
-   */
-  public function testDoesNotHugSelf()
-  {
-      $lostSoul = new LostSoul();
-      $lostSoul->hug($lostSoul);
-  }
+    /**
+     * @expectedException \Exception
+     */
+    public function testDoesNotHugSelf()
+    {
+        $lostSoul = new LostSoul();
+        $lostSoul->hug($lostSoul);
+    }
 
-  /**
-   * Making it to the assertion ensures an infinite loop was not encountered and the hugging terminates
-   */
-  public function testTerminatesHugging()
-  {
-      $lostSoul1 = new LostSoul();
-      $lostSoul2 = new LostSoul();
-      $lostSoul1->hug($lostSoul2);
+    /**
+     * Making it to the assertion ensures an infinite loop was not encountered and the hugging terminates
+     */
+    public function testTerminatesHugging()
+    {
+        $lostSoul1 = new LostSoul();
+        $lostSoul2 = new LostSoul();
+        $lostSoul1->hug($lostSoul2);
 
-      $this->assertTrue(true);
-  }
+        $this->assertTrue(true);
+    }
 
-  /**
-   * Making it to the assertion ensures an infinite loop was not encountered and the hugging terminates when a
-   * specific amount of $loveNeeded is defined.
-   */
-  public function testTerminatesDefinedHugging()
-  {
-      $lostSoul1 = new LostSoul(2);
-      $lostSoul2 = new LostSoul(4);
-      $lostSoul1->hug($lostSoul2);
+    /**
+     * Making it to the assertion ensures an infinite loop was not encountered and the hugging terminates when a
+     * specific amount of $loveNeeded is defined.
+     */
+    public function testTerminatesDefinedHugging()
+    {
+        $lostSoul1 = new LostSoul(2);
+        $lostSoul2 = new LostSoul(4);
+        $lostSoul1->hug($lostSoul2);
 
-      $this->assertTrue(true);
-  }
+        $this->assertTrue(true);
+    }
 }

--- a/tests/LostSoulTest.php
+++ b/tests/LostSoulTest.php
@@ -36,7 +36,32 @@ final class LostSoulTest extends TestCase
    */
   public function testDoesNotHugSelf()
   {
-    $lostSoul = new LostSoul();
-    $lostSoul->hug($lostSoul);
+      $lostSoul = new LostSoul();
+      $lostSoul->hug($lostSoul);
+  }
+
+  /**
+   * Making it to the assertion ensures an infinite loop was not encountered and the hugging terminates
+   */
+  public function testTerminatesHugging()
+  {
+      $lostSoul1 = new LostSoul();
+      $lostSoul2 = new LostSoul();
+      $lostSoul1->hug($lostSoul2);
+
+      $this->assertTrue(true);
+  }
+
+  /**
+   * Making it to the assertion ensures an infinite loop was not encountered and the hugging terminates when a
+   * specific amount of $loveNeeded is defined.
+   */
+  public function testTerminatesDefinedHugging()
+  {
+      $lostSoul1 = new LostSoul(2);
+      $lostSoul2 = new LostSoul(4);
+      $lostSoul1->hug($lostSoul2);
+
+      $this->assertTrue(true);
   }
 }

--- a/tests/LostSoulTest.php
+++ b/tests/LostSoulTest.php
@@ -30,4 +30,13 @@ final class LostSoulTest extends TestCase
         // reveal the prophecy and create an actual test double object
         $lostSoul->hug($mock->reveal());
     }
+
+  /**
+   * @expectedException \Exception
+   */
+  public function testDoesNotHugSelf()
+  {
+    $lostSoul = new LostSoul();
+    $lostSoul->hug($lostSoul);
+  }
 }


### PR DESCRIPTION
Fixes #13 

- [x] Confirm an exception is thrown when a `LostSoul` attempts to hug themselves
- [x] The `Huggable $soul` passed to `hug()` receives a hug

```
$ npm test

> psr-8@0.1.0 test /Users/darrenlee/Documents/Projects/PSR-8
> php ./vendor/bin/phpunit --verbose tests

PHPUnit 6.0.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.2 with Xdebug 2.5.1
Configuration: /Users/darrenlee/Documents/Projects/PSR-8/phpunit.xml.dist

....                                                                4 / 4 (100%)

Time: 142 ms, Memory: 6.00MB

OK (4 tests, 4 assertions)


Code Coverage Report:
  2017-03-27 01:49:38

 Summary:
  Classes: 100.00% (1/1)
  Methods: 100.00% (2/2)
  Lines:   100.00% (10/10)

\DeeZone\Hug::LostSoul
  Methods: 100.00% ( 2/ 2)   Lines: 100.00% ( 10/ 10)
```

