### PR TITLE
ISSUE-15 : Restructure tests to isolate tests

### DIFF
--- a/src/LostSoul.php
+++ b/src/LostSoul.php
@@ -1,7 +1,7 @@
 <?php
   /**
    * There are many lost souls in various states of mind. With a few hugs their state or at least their
-   * properties can be changed. Once a lost soul is hugged it will inspire them to hug back which ultmatly
+   * properties can be changed. Once a lost soul is hugged it will inspire them to hug back which ultimately
    * will make the world a better place. Or so it is believed:
    * http://health.usnews.com/health-news/health-wellness/articles/2016-02-03/the-health-benefits-of-hugging
    */

--- a/tests/LostSoulTest.php
+++ b/tests/LostSoulTest.php
@@ -69,54 +69,42 @@ final class LostSoulTest extends TestCase
     }
 
     /**
-     * The effects of a first time hug should effect the WarmAndFuzzy and TimesHugged values for the LostSoul
+     * Ensure that a new LostSoul starts with initial zero values for WarmAndFuzzy as well as TimesHugged.
      */
-    public function testWarmAndFuzzyAndTimesHugged()
+    public function testInitialWarmAndFuzzyAndTimesHuggedValues()
     {
-        $lostSoul1 = new LostSoul();
+        $lostSoul = new LostSoul();
 
         // Test WarmAndFuzzy value of new LostSoul
-        $lostSoul1WarmAndFuzzyBefore = $lostSoul1->getWarmAndFuzzy();
-        $this->assertInternalType("int", $lostSoul1WarmAndFuzzyBefore);
-        $this->assertTrue($lostSoul1WarmAndFuzzyBefore >= 0);
+        $lostSoulWarmAndFuzzyBefore = $lostSoul->getWarmAndFuzzy();
+        $this->assertInternalType("int", $lostSoulWarmAndFuzzyBefore);
+        $this->assertTrue($lostSoulWarmAndFuzzyBefore >= 0);
 
         // Test TimesHugged value of new LostSoul
-        $lostSoul1TimesHugged = $lostSoul1->getTimesHugged();
-        $this->assertInternalType("int", $lostSoul1TimesHugged);
-        $this->assertTrue($lostSoul1TimesHugged == 0);
+        $lostSoulTimesHugged = $lostSoul->getTimesHugged();
+        $this->assertInternalType("int", $lostSoulTimesHugged);
+        $this->assertTrue($lostSoulTimesHugged == 0);
+    }
 
+    /**
+     * The effects of a first time hug should increase the WarmAndFuzzy and TimesHugged values for the LostSoul
+     */
+    public function testWarmAndFuzzyAndTimesHuggedAfterHug()
+    {
+        $lostSoul1 = new LostSoul();
         $lostSoul2 = new LostSoul();
-
-        $lostSoul2WarmAndFuzzyBefore = $lostSoul2->getWarmAndFuzzy();
-        $this->assertInternalType("int", $lostSoul2WarmAndFuzzyBefore);
-        $this->assertTrue($lostSoul2WarmAndFuzzyBefore >= 0);
-
-        $lostSoul2TimesHugged = $lostSoul2->getTimesHugged();
-        $this->assertInternalType("int", $lostSoul2TimesHugged);
-        $this->assertTrue($lostSoul2TimesHugged == 0);
-
         $lostSoul1->hug($lostSoul2);
 
         // Test that WarmAndFuzzy has changed
         $lostSoul1WarmAndFuzzyAfter = $lostSoul1->getWarmAndFuzzy();
-        $this->assertTrue($lostSoul1WarmAndFuzzyBefore != $lostSoul1WarmAndFuzzyAfter);
+        $this->assertTrue(0 != $lostSoul1WarmAndFuzzyAfter);
         $lostSoul2WarmAndFuzzyAfter = $lostSoul2->getWarmAndFuzzy();
-        $this->assertTrue($lostSoul2WarmAndFuzzyBefore != $lostSoul2WarmAndFuzzyAfter);
+        $this->assertTrue(0 != $lostSoul2WarmAndFuzzyAfter);
 
         // Test that times hugged has increased by at least 1
         $lostSoul1TimesHugged = $lostSoul1->getTimesHugged();
         $this->assertTrue($lostSoul1TimesHugged >= 1);
         $lostSoul2TimesHugged = $lostSoul2->getTimesHugged();
         $this->assertTrue($lostSoul2TimesHugged >= 1);
-    }
-
-    /**
-     * When a LostSoul has reached WarmAndFuzzy maximum the hugging should stop. WarmAndFuzzy and TimesHugged values
-     * should be unchanged.
-     */
-    public function testKeepHugging()
-    {
-        $this->markTestSkipped('-> Must be completed.');
-        $this->assertTrue(false);
     }
 }


### PR DESCRIPTION
Fixes #15 

Restructure tests to isolate tests for initial warmAndFuzzy and hugged values vs the effects of the keepHugging() and hugImpact() methods on warmAndFuzzy and hugged properties.

